### PR TITLE
Add validation for pending payments

### DIFF
--- a/borrowings/views.py
+++ b/borrowings/views.py
@@ -1,5 +1,6 @@
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, viewsets
+from rest_framework.exceptions import PermissionDenied
 from rest_framework.permissions import IsAuthenticated
 
 from borrowings.filters import BorrowingFilter
@@ -10,6 +11,7 @@ from borrowings.serializers import (
     BorrowingListSerializer,
     BorrowingSerializer,
 )
+from payments.models import Payment
 
 
 class BorrowingViewSet(
@@ -33,6 +35,15 @@ class BorrowingViewSet(
         return BorrowingSerializer
 
     def perform_create(self, serializer):
+        has_pending_payment = Payment.objects.filter(
+            borrowing__user=self.request.user,
+            status=Payment.Status.PENDING,
+        ).exists()
+        if has_pending_payment:
+            raise PermissionDenied(
+                "You have unpaid payments. "
+                "Please settle them before borrowing new books."
+            )
         serializer.save(user=self.request.user)
 
     def get_queryset(self):


### PR DESCRIPTION
Deny users to borrow new books if there’s at least one pending payment for the user:
1. Before creating a borrowing, check the number of pending payments
2. If at least one has been found, deny borrowing